### PR TITLE
Exclude manage.py from pylint action

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -21,4 +21,4 @@ jobs:
         pip install -r requirements.txt
     - name: Analysing the code with pylint
       run: |
-        pylint $(git ls-files '*.py')
+        pylint $(git ls-files -- '*.py' ':!:manage.py')


### PR DESCRIPTION
Exclude manage.py from Pylint action to avoid unnecessary warnings (we have no reason to change manage.py, so the styling is irrelevant)