### PR TITLE
Ensures home only shows approved events

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -17,6 +17,7 @@ from .forms import SignInForm, SignUpForm, CreateEventForm
 
 def index(request: HttpRequest) -> HttpResponse:
     events = Event.objects.all()
+    events = events.filter(approved="1",  date__date__gte=timezone.now().date())
     return render(request, "home.html", {"events":events})
 
 def discover(request: HttpRequest) -> HttpResponse:


### PR DESCRIPTION
Specifically, this now uses the same filter as the discover page, meaning that events will be filtered so that they must have been approved and must not have already occurred