### PR TITLE
Fixed tab titles

### DIFF
--- a/app/templates/approval.html
+++ b/app/templates/approval.html
@@ -155,6 +155,7 @@
 </script>
 
 {% extends "base.html" %}
+{% block title %}Approval - UWeave{% endblock %}
 {% block content %}
 <body>
     <h2 class="page-title">Approve Events</h2>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,7 +1,7 @@
 <html lang="en">
 
 <head>
-    <title>{% block title %}{% endblock %}</title>
+    <title>{% block title %}UWeave{% endblock %}</title>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>

--- a/app/templates/discover.html
+++ b/app/templates/discover.html
@@ -158,6 +158,7 @@
 </script>
 
 {% extends "base.html" %}
+{% block title %}Discover - UWeave{% endblock %}
 {% block content %}
 <body>
     <!-- Navbar -->

--- a/app/templates/edit_event.html
+++ b/app/templates/edit_event.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Home{% endblock %}
+{% block title %}Oranise - UWeave{% endblock %}
 
 {% block content %}
 <div class="container mt-5">

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Home - UWeave{% endblock %}
 
 {% block content %}
 

--- a/app/templates/my_events.html
+++ b/app/templates/my_events.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Home{% endblock %}
+{% block title %}My Events - UWeave{% endblock %}
 
 {% block content %}
 <div class="container mt-5">

--- a/app/templates/organise.html
+++ b/app/templates/organise.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Home{% endblock %}
+{% block title %}Organise - UWeave{% endblock %}
 
 {% block content %}
 <div class="container mt-5">

--- a/app/templates/password_reset_complete.html
+++ b/app/templates/password_reset_complete.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Password Reset - UWeave{% endblock %}
 
 {% block content %}
 <div class="container mt-5">

--- a/app/templates/password_reset_confirm.html
+++ b/app/templates/password_reset_confirm.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Password Reset - UWeave{% endblock %}
 
 {% block content %}
 <div class="container mt-5">

--- a/app/templates/password_reset_done.html
+++ b/app/templates/password_reset_done.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Password Reset - UWeave{% endblock %}
 {% block content %}
 <div class="container mt-5">
   <div class="row">

--- a/app/templates/password_reset_form.html
+++ b/app/templates/password_reset_form.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Password Reset - UWeave{% endblock %}
 
 {% block content %}
 <div class="container mt-5">

--- a/app/templates/sign_in.html
+++ b/app/templates/sign_in.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Sign In - UWeave{% endblock %}
 
 {% block content %}
 <style>

--- a/app/templates/sign_up.html
+++ b/app/templates/sign_up.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Sign Up - UWeave{% endblock %}
 
 {% block content %}
 


### PR DESCRIPTION
Overridden current webpage titles to the convention of 'PageName - UWeave'. Also added the default value of a new webpage when not assigned to just display 'UWeave' as the tab title.