### PR TITLE
Added 403 error page

### DIFF
--- a/app/templates/403.html
+++ b/app/templates/403.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% block title %}Error - UWeave{% endblock %}
+{% block content %}
+<div class="container mt-5 justify-content-center">
+    <h1>Forbidden (error 403)</h1>
+    <p>You do not have the permissions required to access this page.</p>
+</div>
+{%endblock%}


### PR DESCRIPTION
Same structure to the 404 and 500 error pages, but taking into account 'forbidden' error.

![image](https://github.com/user-attachments/assets/eb77a593-57a2-4610-bd34-4eb56037b8f0)
^ achieved when navigated to /organise when signed in as a Student