### PR TITLE
Changed name of event iterator for the edit event view

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -237,9 +237,9 @@ def edit_event(request: HttpRequest, event_id: int) -> HttpResponse:
     )
     events = list(Event.objects.all())
     valid_events = []
-    for eventIterator in events:
-        if eventIterator.organiser in potential_organisers:
-            valid_events.append(eventIterator)
+    for event_iterator in events:
+        if event_iterator.organiser in potential_organisers:
+            valid_events.append(event_iterator)
 
     # If the request method is POST, process the form data
     if request.method == "POST":


### PR DESCRIPTION
Changed the name of the iterator used to iterate through potential events to display when managing events, so that it does not use the same name as the variable used to display the currently selected event.