### PR TITLE
Stop soc reps from editing events they should not be able to access

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -289,7 +289,10 @@ def edit_event(request: HttpRequest, event_id: int) -> HttpResponse:
     # Get the event requested, if it is in the valid events.
     event = [x for x in valid_events if x.organiser in potential_organisers and x.id == event_id]
     if len(event) == 0:
-        return HttpResponse("You do not have permissions to access an event with the given ID.", status=404)
+        return HttpResponse(
+            "You do not have permissions to access an event with the given ID.",
+            status=404
+        )
     event = event[0]
     # If the request method is POST, process the form data
     if request.method == "POST":

--- a/app/views.py
+++ b/app/views.py
@@ -6,6 +6,7 @@ from django.contrib.auth.forms import PasswordResetForm
 from django.contrib.auth.views import PasswordResetConfirmView
 from django.http import HttpResponse, HttpRequest
 from django.contrib.auth.decorators import login_required, permission_required
+from django.core.exceptions import PermissionDenied
 from django.utils import timezone
 # model imports
 from app.models import Event, Booking, Student, SocietyRepresentative, Location


### PR DESCRIPTION
Simple fix so that it will fetch the main event from the pool of authorised events rather than fetching it by ID from all events.