### PR TITLE
Unit test the discover page search priority calculation

### DIFF
--- a/app/tests.py
+++ b/app/tests.py
@@ -1,10 +1,17 @@
 """Test cases for the app."""
 
+from datetime import datetime
+from zoneinfo import ZoneInfo
+from uuid import uuid4
 from django.test import TestCase
 from django.http import HttpRequest
+# pylint: disable=imported-auth-user
+from django.contrib.auth.models import User
 import cv2
-import numpy
+import numpy as np
 from mysite.generators import get_qrcode_from_response
+from mysite.algorithms import get_event_search_priority
+from .models import Event, SocietyRepresentative
 
 class QRFromRequestTestCase(TestCase):
     """Test generating QR codes from requests.
@@ -22,7 +29,42 @@ class QRFromRequestTestCase(TestCase):
 
     def test_get_qrcode_from_response(self) -> None:
         """Test if the generated QR code contains the target URL."""
-        qr_image = numpy.frombuffer(get_qrcode_from_response(self.request), numpy.uint8)
+        qr_image = np.frombuffer(get_qrcode_from_response(self.request), np.uint8)
         decoded_image = cv2.imdecode(qr_image, flags=cv2.IMREAD_COLOR_BGR)
         url, _, _ = self.qr_reader.detectAndDecode(decoded_image)
         self.assertEqual(url, self.target_url)
+
+class EventSearchTestCase(TestCase):
+    """Test the event search system.
+
+    @author Tricia Sibley
+    """
+
+    def setUp(self) -> None:
+        """Create some events to sort."""
+        event_data = (
+            ("whole test query", "", "", 5),
+            ("whole test query extra", "", "", 4),
+            ("", "whole test query", "", 3),
+            ("whole other idea", "", "", 2),
+            ("", "", "whole test query", 1),
+            ("", "", "", 0),
+        )
+        self.test_events = []
+        for data in event_data:
+            user = User.objects.create(username=uuid4())
+            rep = SocietyRepresentative.objects.create(user=user, society_name=data[2])
+            date = datetime.now(tz=ZoneInfo("Europe/London"))
+            event = Event.objects.create(
+                name=data[0],
+                description=data[1],
+                date=date,
+                organiser=rep,
+            )
+            self.test_events.append((event, data[3]))
+
+    def test_get_priority(self) -> None:
+        """Test if the event priority calculation produces expected results."""
+        query = "whole test query"
+        for event, priority in self.test_events:
+            self.assertEqual(get_event_search_priority(event, query), priority)

--- a/app/views.py
+++ b/app/views.py
@@ -45,7 +45,8 @@ def index(request: HttpRequest) -> HttpResponse:
 def discover(request: HttpRequest) -> HttpResponse:
     """Filter events based on user input.
 
-    @author  Tilly Searle
+    @author Tilly Searle
+    @author Seth Mallinson
     """
     search_query = request.GET.get("search_query", "").lower()
     event_date = request.GET.get("event_date", "")
@@ -72,9 +73,15 @@ def discover(request: HttpRequest) -> HttpResponse:
     # the search, and remainders will be ordered by priority - a full name match is higher priority
     # than one word of the query matching for example.
     if search_query:
-        events_for_ordering = [[event, search_query, 0] for event in events]
-        events_for_ordering.sort(key=get_event_search_priority)
-        events = [thing[0] for thing in events_for_ordering if thing[2] < 4]
+        # Temporary function to bind search query to the priority calculation
+        def sorter(event: Event) -> int:
+            return get_event_search_priority(event, search_query)
+
+        # Filter out events with a priority of 0 (no relation to query)
+        events = [event for event in events if sorter(event) > 0]
+
+        # Sort remaining events
+        events.sort(key=sorter, reverse=True)
 
     booked_events = set()
     if request.user.is_authenticated and Student.objects.filter(user=request.user).exists():


### PR DESCRIPTION
Adds a test case for the `get_event_search_priority()` function.

The function has also been simplified, to only return the priority rather than doing any in-place assignments. The surrounding code has been changed to do a first filter-pass of the list, followed by a full sort. This makes the function easier to test (and possibly a bit faster, but I'm unsure).