### PR TITLE
Fix login redirect

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -433,6 +433,9 @@ def sign_in(request: HttpRequest) -> HttpResponse:
                     "error": "Invalid username or password",
                 })
             login(request, user)
+            if request.GET:
+                next_page = request.GET.get("next", "home")
+                return redirect(next_page)
             return redirect("home")
     else:
         form = SignInForm()

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -12,6 +12,8 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 import os
 from pathlib import Path
 
+LOGIN_URL = "/sign-in"
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 


### PR DESCRIPTION
Fixes the login redirect. Now, when you navigate to a page with the `@login_required` decorator, it will redirect you to the login page, and then back to the page you intended to reach once you log in.